### PR TITLE
fix deprecation error/crash - add disabledeprecation to conf

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -89,6 +89,7 @@ Bitcoin.DEFAULT_CONFIG_SETTINGS = {
   rpcallowip: '127.0.0.1',
   rpcuser: 'bitcoin',
   rpcpassword: 'local321',
+  disabledeprecation: '1.1.0',
   uacomment: 'bitcore'
 };
 


### PR DESCRIPTION
```
Error: This version has been deprecated as of block height 369112. You should upgrade to the latest version of Zcash. To disable deprecation for this version, set 'disabledeprecation' to '1.1.0'.
[2018-08-02T22:53:56.942Z] warn: Rewinding blocks if needed...
[2018-08-02T22:53:57.497Z] warn: ZMQ disconnect: tcp://127.0.0.1:28332
[2018-08-02T22:53:57.497Z] warn: ZMQ connection delay: tcp://127.0.0.1:28332
[2018-08-02T22:53:57.497Z] warn: ZMQ connection delay: tcp://127.0.0.1:28332
[2018-08-02T22:53:57.535Z] warn: Zcash process unexpectedly exited with code: 1
[2018-08-02T22:53:57.535Z] warn: Restarting zcash child process in 5000ms
```