### PR TITLE
Config path

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -89,6 +89,7 @@ Bitcoin.DEFAULT_CONFIG_SETTINGS = {
   rpcallowip: '127.0.0.1',
   rpcuser: 'bitcoin',
   rpcpassword: 'local321',
+  disabledeprecation: '1.1.0',
   uacomment: 'bitcore'
 };
 

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -89,7 +89,6 @@ Bitcoin.DEFAULT_CONFIG_SETTINGS = {
   rpcallowip: '127.0.0.1',
   rpcuser: 'bitcoin',
   rpcpassword: 'local321',
-  disabledeprecation: '1.1.0',
   uacomment: 'bitcore'
 };
 

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -339,7 +339,7 @@ Bitcoin.prototype._loadSpawnConfiguration = function(node) {
   this._expandRelativeDatadir();
 
   var spawnOptions = this.options.spawn;
-  var configPath = path.resolve(spawnOptions.datadir, './zcash.conf');
+  var configPath = (spawnOptions['configPath']) ? path.resolve(spawnOptions.configPath) : path.resolve(spawnOptions.datadir, './zcash.conf');
 
   log.info('Using zcash config file:', configPath);
 


### PR DESCRIPTION
This code allows `configPath` to be specified in `bitcore-node.json` under `bitcoind`->`spawn` so that the datadir and conf file can be separate.